### PR TITLE
Remove speech only "notification permissions"

### DIFF
--- a/ios/RCTSpeechNotification/SpeechNotificationDelegate.m
+++ b/ios/RCTSpeechNotification/SpeechNotificationDelegate.m
@@ -30,10 +30,6 @@
 
 - (void)speak:(NSDictionary*)args
 {
-  if ([UIApplication instancesRespondToSelector:@selector(registerUserNotificationSettings:)]) {
-    [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:UIUserNotificationTypeAlert|UIUserNotificationTypeBadge|UIUserNotificationTypeSound categories:nil]];
-  }
-
   [[AVAudioSession sharedInstance] setActive:NO withOptions:0 error:nil];
   [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers error:nil];
 


### PR DESCRIPTION
The user was asked for notification permissions, even if only TTS is used. This has been removed.
